### PR TITLE
fix: Update GitHub Pages deployment path to packages/othello-react/dist

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: './dist'
+          path: './packages/othello-react/dist'
 
   # Deployment job
   deploy:


### PR DESCRIPTION
- Changed artifact upload path from './dist' to './packages/othello-react/dist'
- Fixes 'Cannot open: No such file or directory' error in deployment