### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -5,6 +5,9 @@ on:
     branches: [main, develop]
     types: [opened, synchronize, reopened, ready_for_review]
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cozyGarage/Othello/security/code-scanning/2](https://github.com/cozyGarage/Othello/security/code-scanning/2)

In general, the fix is to explicitly declare a `permissions` block in the workflow so that the `GITHUB_TOKEN` used in this job is restricted to the minimal set it actually needs. Here, the job only reads the repository contents (via `actions/checkout`) and does not write to the repo, issues, or pull requests. Therefore, the minimal safe permissions are `contents: read`. To implement this without changing functionality, add a `permissions` block at the root level (so it applies to all jobs) before the `jobs:` key in `.github/workflows/pr-validation.yml`. No extra methods, imports, or definitions are needed; this is a pure YAML configuration change.

Concretely: in `.github/workflows/pr-validation.yml`, after the `on:` section (or before `jobs:`), insert:

```yaml
permissions:
  contents: read
```

This constrains the `GITHUB_TOKEN` for the `validate` job and satisfies the CodeQL rule while preserving existing behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
